### PR TITLE
Fix deprecation warning for solr.xml template

### DIFF
--- a/templates/solr.xml.erb
+++ b/templates/solr.xml.erb
@@ -1,8 +1,8 @@
 <solr persistent="true" sharedLib="lib">
  <cores adminPath="/admin/cores">
-  <% cores.each do |core| %>
-    <core name="<%=core%>" instanceDir="<%=core%>"
-          dataDir="/var/lib/solr/<%=core%>" />
+  <% @cores.each do |core| %>
+    <core name="<%= core -%>" instanceDir="<%= core -%>"
+          dataDir="/var/lib/solr/<%= core -%>" />
   <% end %>
  </cores>
 </solr>


### PR DESCRIPTION
This change fixes the deprecation warning that puppet 3.3 emits.
