### PR TITLE
Added $path to solr download resource

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,6 +39,7 @@ class solr::config(
 
   # download only if WEB-INF is not present and tgz file is not in /tmp:
   exec { 'solr-download':
+    path      =>  ['/usr/bin', '/usr/sbin', '/bin'],
     command   =>  "wget ${download_url}",
     cwd       =>  '/tmp',
     creates   =>  "/tmp/${dl_name}",


### PR DESCRIPTION
This failed on my ubuntu machines without the 'path'
