### PR TITLE
Avoid Package['curl'] if already defined for node

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,8 +25,10 @@ class solr::install {
     ensure  => present,
   }
 
-  package { 'curl':
-    ensure  => present,
+  if !Package['curl'] {
+    package { 'curl':
+      ensure  => present,
+    }
   }
 }
 


### PR DESCRIPTION
Currently, when Package['curl'] is already defined for the node, this will throw errors. My commit fixes that.