### PR TITLE
Avoid errors about path not being set for test

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -54,6 +54,7 @@ class solr::config(
     cwd       =>  '/tmp',
     onlyif    =>  "test -f /tmp/${dl_name} && test ! -d /tmp/solr-${version}",
     require   =>  Exec['solr-download'],
+    path      => "/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin"
   }
 
   # have to copy logging jars separately from solr 4.3 onwards


### PR DESCRIPTION
I get errors about path not being specified for the test in "onlyif". This fixes it.