### PR TITLE
Fix conflict with composer

### DIFF
--- a/files/jetty-default
+++ b/files/jetty-default
@@ -16,7 +16,7 @@ VERBOSE=yes
 JETTY_HOST=0.0.0.0
 
 # The network port used by Jetty
-JETTY_PORT=8080
+JETTY_PORT=8983
 
 # Timeout in seconds for the shutdown of all webapps
 #JETTY_SHUTDOWN=30

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,7 +25,7 @@ class solr::install {
     ensure  => present,
   }
 
-  if defined(Package['curl'] == false {
+  if defined(Package['curl']) == false {
     package { 'curl':
       ensure  => present,
     }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,8 +25,10 @@ class solr::install {
     ensure  => present,
   }
 
-  package { 'curl':
-    ensure  => present,
+  if defined(Package['curl'] == false {
+    package { 'curl':
+      ensure  => present,
+    }
   }
 }
 


### PR DESCRIPTION
This is a fix for error
```sh
Error: Duplicate declaration: Package[curl] is already declared in file /etc/puppet/modules/composer/manifests/init.pp:88; cannot redeclare at /etc/puppet/modules/solr/manifests/install.pp:28 on node precise64
Error: Duplicate declaration: Package[curl] is already declared in file /etc/puppet/modules/composer/manifests/init.pp:88; cannot redeclare at /etc/puppet/modules/solr/manifests/install.pp:28 on node precise64
```
that was because of conflict of package names with https://github.com/puphpet/puppet-composer.git