### PR TITLE
Fixed "Cannot write to config directory" warning

### DIFF
--- a/manifests/core.pp
+++ b/manifests/core.pp
@@ -26,6 +26,8 @@ define solr::core(
   #Copy its config over
   file { "${solr_home}/${core_name}/conf":
     ensure  => directory,
+    owner   => 'jetty',
+    group   => 'jetty',
     recurse => true,
     source  => 'puppet:///modules/solr/conf',
     require => File["${solr_home}/${core_name}"],


### PR DESCRIPTION
In the logs there were "WARN  org.apache.solr.rest.ManagedResourceStorage  - Cannot write to config directory /usr/share/solr/skyzon-org/conf; switching to use InMemory storage instead."
