### PR TITLE
Update Solr download URL.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class solr::params {
   $jetty_home    = '/usr/share/jetty'
   $solr_home     = '/usr/share/solr'
   $solr_version  = '4.7.2'
-  $mirror_site   = 'http://www.us.apache.org/dist/lucene/solr'
+  $mirror_site   = 'http://archive.apache.org/dist/lucene/solr'
   $data_dir      = '/var/lib/solr'
   $cores         = ['default']
   $dist_root     = '/tmp'


### PR DESCRIPTION
The mirror URL in the repository is no longer valid.