### PR TITLE
Fix solr.xml template to work with pull request 28 (Issue #6)

### DIFF
--- a/templates/solr.xml.erb
+++ b/templates/solr.xml.erb
@@ -1,8 +1,15 @@
 <solr persistent="true" sharedLib="lib">
  <cores adminPath="/admin/cores">
-  <% @cores.each do |core| %>
-    <core name="<%= core -%>" instanceDir="<%= core -%>"
+<% if @cores.is_a?(Hash)
+     @cores.each_pair do |core,value| -%>
+   <core name="<%= core -%>" instanceDir="<%= @solr_home -%>/<%= core -%>" dataDir="/var/lib/solr/<%=
+core -%>" />
+<%   end
+   else
+     [ @cores ].flatten.each do |core| -%>
+    <core name="<%= core -%>" instanceDir="<%= @solr_home -%>/<%= core -%>"
           dataDir="/var/lib/solr/<%= core -%>" />
-  <% end %>
+<%   end
+   end -%>
  </cores>
 </solr>


### PR DESCRIPTION
Pull request 28 (https://github.com/vamsee/puppet-solr/pull/28) updates the way cores are specified but the template was never updated. This should handle cores as hash, array or string.