### PR TITLE
Fix systemd init.d

### DIFF
--- a/files/jetty-default
+++ b/files/jetty-default
@@ -25,7 +25,7 @@ JETTY_PORT=8983
 #JETTY_ARGS=
 
 # Extra options to pass to the JVM         
-JAVA_OPTIONS="-Dsolr.solr.home=/usr/share/solr $JAVA_OPTIONS"
+JAVA_OPTIONS="-Dsolr.solr.home=/usr/share/solr -Dsolr.data.dir=/var/lib/solr $JAVA_OPTIONS"
 
 # Home of Java installation.
 # JAVA_HOME=

--- a/files/jetty8
+++ b/files/jetty8
@@ -1,0 +1,429 @@
+#!/bin/sh -e
+#
+# /etc/init.d/jetty8 -- startup script for jetty 8.1.1
+#
+# Written by Philipp Meier <meier@meisterbohne.de>
+# Modified for Jetty 6 by Ludovic Claude <ludovic.claude@laposte.net>
+# Modified for Jetty 8 by Jakub Adam <jakub.adam@ktknet.cz>
+#
+### BEGIN INIT INFO
+# Provides:          jetty8
+# Required-Start:    $local_fs $remote_fs $network
+# Required-Stop:     $local_fs $remote_fs $network
+# Should-Start:      $named
+# Should-Stop:       $named
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start Jetty
+# Description:       Start Jetty HTTP server and servlet container.
+### END INIT INFO
+
+# Configuration files
+#
+# /etc/default/jetty8
+#   If it exists, this is read at the start of script. It may perform any
+#   sequence of shell commands, like setting relevant environment variables.
+#
+# /etc/jetty8/jetty.conf
+#   If found, the file will be used as this script's configuration.
+#   Each line in the file may contain:
+#     - A comment denoted by the pound (#) sign as first non-blank character.
+#     - The path to a regular file, which will be passed to jetty as a
+#       config.xml file.
+#     - The path to a directory. Each *.xml file in the directory will be
+#       passed to jetty as a config.xml file.
+#
+#   The files will be checked for existence before being passed to jetty.
+#
+# /etc/jetty8/jetty.xml
+#   If found, used as this script's configuration file, but only if
+#   /etc/jetty8/jetty.conf was not present. See above.
+#
+# Configuration variables (to define in /etc/default/jetty8)
+#
+# JAVA_HOME
+#   Home of Java installation.
+#
+# JAVA_OPTIONS
+#   Extra options to pass to the JVM
+#
+# JETTY_PORT
+#   Override the default port for Jetty servers. If not set then 8080
+#   will be used. The java system property "jetty.port" will be set to
+#   this value for use in configure.xml files. For example, the following
+#   idiom is widely used in the demo config files to respect this property
+#   in Listener configuration elements:
+#
+#    <Set name="Port"><SystemProperty name="jetty.port" default="8080"/></Set>
+#
+# JETTY_ARGS
+#   The default arguments to pass to jetty.
+#
+# JETTY_USER
+#   if set, then used as a username to run the server as
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+VERSION=8
+NAME=jetty$VERSION
+DESC="Jetty $VERSION Servlet Engine"
+JETTY_HOME=/usr/share/$NAME
+LOGDIR="/var/log/$NAME"
+START_JAR="$JETTY_HOME/start.jar"
+DEFAULT=/etc/default/$NAME
+JVM_TMP=/var/cache/$NAME/tmp
+
+if [ `id -u` -ne 0 ]; then
+	echo "You need root privileges to run this script"
+	exit 1
+fi
+
+# Make sure jetty is started with system locale
+if [ -r /etc/default/locale ]; then
+	. /etc/default/locale
+	export LANG
+fi
+
+. /lib/lsb/init-functions
+
+if [ -r /etc/default/rcS ]; then
+	. /etc/default/rcS
+fi
+
+
+# The following variables can be overwritten in /etc/default/jetty
+
+# Whether to start jetty (as a daemon) or not
+NO_START=0
+
+# Run Jetty as this user ID (default: jetty)
+# Set this to an empty string to prevent Jetty from starting automatically
+JETTY_USER=jetty
+
+# Listen to connections from this network host (leave empty to accept all connections)
+#JETTY_HOST=$(uname -n)
+JETTY_HOST=0.0.0.0
+
+# The network port used by Jetty
+JETTY_PORT=8080
+
+# Additional arguments to pass to Jetty
+JETTY_ARGS=
+
+JETTY_STATE=/var/lib/jetty$VERSION/jetty.state
+
+# Extra options to pass to the JVM
+# Set java.awt.headless=true if JAVA_OPTIONS is not set so the
+# Xalan XSL transformer can work without X11 display on JDK 1.4+
+# It also sets the maximum heap size to 256M to deal with most cases.
+JAVA_OPTIONS="-Xmx256m -Djava.awt.headless=true"
+
+# This function sets the variable JDK_DIRS
+find_jdks()
+{
+    for java_version in 9 8 7 6
+    do
+        for jvmdir in /usr/lib/jvm/java-${java_version}-openjdk-* \
+                      /usr/lib/jvm/jdk-${java_version}-oracle-* \
+                      /usr/lib/jvm/jre-${java_version}-oracle-* \
+                      /usr/lib/jvm/java-${java_version}-oracle
+        do
+            if [ -d "${jvmdir}" -a "${jvmdir}" != "/usr/lib/jvm/java-${java_version}-openjdk-common" ]
+            then
+                JDK_DIRS="${JDK_DIRS} ${jvmdir}"
+            fi
+        done
+    done
+
+    # Add the paths for the JVMs packaged by the older versions of java-package (<< 0.52 as in Wheezy and Trusty)
+    JDK_DIRS="${JDK_DIRS} /usr/lib/jvm/j2re1.7-oracle /usr/lib/jvm/j2sdk1.7-oracle /usr/lib/jvm/java-6-openjdk /usr/lib/jvm/java-6-sun"
+}
+
+# The first existing directory is used for JAVA_HOME (if JAVA_HOME is not
+# defined in $DEFAULT)
+JDK_DIRS="/usr/lib/jvm/default-java"
+find_jdks
+
+# Timeout in seconds for the shutdown of all webapps
+JETTY_SHUTDOWN=30
+
+# Jetty uses a directory to store temporary files like unpacked webapps
+JETTY_TMP=/var/cache/jetty$VERSION/data
+
+# Jetty uses a config file to setup its boot classpath
+JETTY_START_CONFIG=/etc/jetty$VERSION/start.config
+
+# End of variables that can be overwritten in /etc/default/jetty
+
+# overwrite settings from default file
+if [ -f "$DEFAULT" ]; then
+	. "$DEFAULT"
+fi
+
+# Check whether jetty is still installed (it might not be if this package was
+# removed and not purged)
+if [ ! -r "$START_JAR" ]; then
+	log_failure_msg "$NAME is not installed"
+	exit 1
+fi
+
+# Check whether startup has been disabled
+if [ "$NO_START" != "0" -a "$1" != "stop" ]; then
+	[ "$VERBOSE" != "no" ] && log_failure_msg "Not starting jetty - edit /etc/default/jetty$VERSION and change NO_START to be 0 (or comment it out)."
+	exit 0
+fi
+
+if [ -z "$JETTY_USER" ]; then
+	log_failure_msg "Not starting/stopping $DESC as configured"
+	log_failure_msg "(JETTY_USER is empty in /etc/default/jetty$VERSION)."
+	exit 0
+fi
+
+# Look for the right JVM to use
+for jdir in $JDK_DIRS; do
+	if [ -d "$jdir" -a -z "${JAVA_HOME}" ]; then
+		JAVA_HOME="$jdir"
+	fi
+done
+export JAVA_HOME
+
+export JAVA="$JAVA_HOME/bin/java"
+
+JAVA_OPTIONS="$JAVA_OPTIONS \
+	-Djava.io.tmpdir=$JETTY_TMP \
+	-Djava.library.path=/usr/lib \
+	-DSTART=$JETTY_START_CONFIG \
+	-Djetty.home=$JETTY_HOME \
+	-Djetty.logs=$LOGDIR \
+	-Djetty.state=$JETTY_STATE \
+	-Djetty.host=$JETTY_HOST \
+	-Djetty.port=$JETTY_PORT"
+
+export JAVA_OPTIONS
+
+# Define other required variables
+PIDFILE="/var/run/$NAME.pid"
+WEBAPPDIR="$JETTY_HOME/webapps"
+ROTATELOGS=/usr/sbin/rotatelogs
+
+##################################################
+# Check for JAVA_HOME
+##################################################
+if [ -z "$JAVA_HOME" ]; then
+	log_failure_msg "Could not start $DESC because no Java Runtime Environment (JRE)"
+	log_failure_msg "was found. Please download and install Java 6 or higher and set"
+	log_failure_msg "JAVA_HOME in /etc/default/jetty$VERSION to the JDK's installation directory."
+	exit 0
+fi
+
+JETTY_CONF=/etc/jetty$VERSION/jetty.conf
+CONFIG_LINES=$(cat $JETTY_CONF | grep -v "^[[:space:]]*#" | tr "\n" " ")
+
+##################################################
+# Get the list of config.xml files from jetty.conf
+##################################################
+if [ ! -z "${CONFIG_LINES}" ]
+then
+  for CONF in ${CONFIG_LINES}
+  do
+    if [ ! -r "$CONF" ] && [ ! -r "$JETTY_HOME/$CONF" ]
+    then
+      log_warning_msg "WARNING: Cannot read '$CONF' specified in '$JETTY_CONF'"
+    elif [ -f "$CONF" ] || [ -f "$JETTY_HOME/$CONF" ]
+    then
+      # assume it's a configure.xml file
+      CONFIGS="$CONFIGS $CONF"
+    elif [ -d "$CONF" ]
+    then
+      # assume it's a directory with configure.xml files
+      # for example: /etc/jetty.d/
+      # sort the files before adding them to the list of CONFIGS
+      XML_FILES=`ls ${CONF}/*.xml | sort | tr "\n" " "`
+      for FILE in ${XML_FILES}
+      do
+         if [ -r "$FILE" ] && [ -f "$FILE" ]
+         then
+            CONFIGS="$CONFIGS $FILE"
+         else
+           log_warning_msg "WARNING: Cannot read '$FILE' specified in '$JETTY_CONF'"
+         fi
+      done
+    else
+      log_warning_msg "WARNING: Don''t know what to do with '$CONF' specified in '$JETTY_CONF'"
+    fi
+  done
+fi
+
+#####################################################
+# Run the standard server if there's nothing else to run
+#####################################################
+if [ -z "$CONFIGS" ]
+then
+	CONFIGS="/etc/jetty$VERSION/jetty-logging.xml /etc/jetty$VERSION/jetty-started.xml"
+fi
+
+##################################################
+# Do the action
+##################################################
+case "$1" in
+  start)
+	log_daemon_msg "Starting $DESC" "$NAME"
+	if start-stop-daemon --quiet --test --start --pidfile "$PIDFILE" \
+	                --user "$JETTY_USER" --startas "$JAVA" > /dev/null; then
+
+		if [ -f $PIDFILE ] ; then
+			log_warning_msg "$PIDFILE exists, but jetty was not running. Ignoring $PIDFILE"
+		fi
+
+		if [ -s "$LOGDIR/out.log" ]; then
+			log_progress_msg "Rotate logs"
+			$ROTATELOGS "$LOGDIR/out.log" 86400 \
+				< "$LOGDIR/out.log" || true
+		fi
+		> "$LOGDIR/out.log"
+		chown -R $JETTY_USER:adm "$LOGDIR"
+
+		# Remove / recreate JETTY_TMP directory
+		rm -rf "$JETTY_TMP"
+		mkdir "$JETTY_TMP" || {
+			log_failure_msg "could not create $DESC temporary directory at $JETTY_TMP"
+			exit 1
+		}
+		chown $JETTY_USER "$JETTY_TMP"
+
+		# Remove / recreate JVM_TMP directory
+		rm -rf "$JVM_TMP"
+		mkdir "$JVM_TMP" || {
+			log_failure_msg "could not create JVM temporary directory at $JVM_TMP"
+			exit 1
+		}
+		chown $JETTY_USER "$JVM_TMP"
+		cd "$JVM_TMP"
+
+		JETTY_CMD="$JAVA $JAVA_OPTIONS -jar $START_JAR $JETTY_ARGS --daemon $CONFIGS"
+
+		AUTHBIND_COMMAND=""
+		if [ "$AUTHBIND" = "yes" ]; then
+			if [ ! -f "/usr/bin/authbind" ]; then
+				log_failure_msg "Authbind is not installed, please run 'apt-get install authbind' and retry"
+				exit 1
+			fi
+
+			AUTHBIND_COMMAND="/usr/bin/authbind --deep /bin/bash -c "
+			JETTY_CMD="'$JETTY_CMD'"
+		fi
+
+		start-stop-daemon --start --pidfile "$PIDFILE" --chuid "$JETTY_USER" \
+		    --chdir "$JETTY_HOME" --background --make-pidfile -x /bin/bash -- -c \
+		    "$AUTHBIND_COMMAND $JETTY_CMD"
+
+		sleep 10
+		if start-stop-daemon --test --start --pidfile "$PIDFILE" \
+			--user $JETTY_USER --exec "$JAVA" >/dev/null; then
+			log_end_msg 1
+		else
+			log_end_msg 0
+		fi
+
+	else
+		log_warning_msg "(already running)."
+		log_end_msg 0
+		exit 1
+	fi
+	;;
+
+  stop)
+	log_daemon_msg "Stopping $DESC" "$NAME"
+
+	if start-stop-daemon --quiet --test --start --pidfile "$PIDFILE" \
+		--user "$JETTY_USER" --startas "$JAVA" > /dev/null; then
+		if [ -x "$PIDFILE" ]; then
+			log_warning_msg "(not running but $PIDFILE exists)."
+		else
+			log_warning_msg "(not running)."
+		fi
+	else
+		start-stop-daemon --quiet --stop \
+			--pidfile "$PIDFILE" --user "$JETTY_USER" \
+			--startas "$JAVA" > /dev/null
+		while ! start-stop-daemon --quiet --test --start \
+			  --pidfile "$PIDFILE" --user "$JETTY_USER" \
+			  --startas "$JAVA" > /dev/null; do
+			sleep 1
+			log_progress_msg "."
+			JETTY_SHUTDOWN=`expr $JETTY_SHUTDOWN - 1` || true
+			if [ $JETTY_SHUTDOWN -ge 0 ]; then
+				start-stop-daemon --oknodo --quiet --stop \
+					--pidfile "$PIDFILE" --user "$JETTY_USER" \
+					--startas "$JAVA"
+			else
+				log_progress_msg " (killing) "
+				start-stop-daemon --stop --signal 9 --oknodo \
+					--quiet --pidfile "$PIDFILE" \
+					--user "$JETTY_USER"
+			fi
+		done
+		rm -f "$PIDFILE"
+		rm -rf "$JVM_TMP"
+		rm -rf "$JETTY_TMP/*"
+		log_end_msg 0
+	fi
+	;;
+
+  status)
+	if start-stop-daemon --quiet --test --start --pidfile "$PIDFILE" \
+		--user "$JETTY_USER" --startas "$JAVA" > /dev/null; then
+
+		if [ -f "$PIDFILE" ]; then
+		    log_success_msg "$DESC is not running, but pid file exists."
+			exit 1
+		else
+		    log_success_msg "$DESC is not running."
+			exit 3
+		fi
+	else
+		log_success_msg "$DESC is running with pid `cat $PIDFILE`, and is reachable on http://$JETTY_HOST:$JETTY_PORT/"
+	fi
+	;;
+
+  restart|force-reload)
+	if ! start-stop-daemon --quiet --test --start --pidfile "$PIDFILE" \
+		--user "$JETTY_USER" --startas "$JAVA" > /dev/null; then
+		$0 stop $*
+		sleep 1
+	fi
+	$0 start $*
+	;;
+
+  try-restart)
+	if start-stop-daemon --quiet --test --start --pidfile "$PIDFILE" \
+		--user "$JETTY_USER" --startas "$JAVA" > /dev/null; then
+		$0 start $*
+	fi
+	;;
+
+  check)
+	log_success_msg "Checking arguments for Jetty: "
+	log_success_msg ""
+	log_success_msg "PIDFILE        =  $PIDFILE"
+	log_success_msg "JAVA_OPTIONS   =  $JAVA_OPTIONS"
+	log_success_msg "JAVA           =  $JAVA"
+	log_success_msg "JETTY_USER     =  $JETTY_USER"
+	log_success_msg "JETTY_HOST     =  $JETTY_HOST"
+	log_success_msg "JETTY_PORT     =  $JETTY_PORT"
+	log_success_msg "ARGUMENTS      =  $ARGUMENTS"
+
+	if [ -f $PIDFILE ]
+	then
+		log_success_msg "$DESC is running with pid `cat $PIDFILE`, and is reachable on http://$JETTY_HOST:$JETTY_PORT/"
+		exit 0
+	fi
+	exit 1
+	;;
+
+  *)
+	log_success_msg "Usage: $0 {start|stop|restart|force-reload|try-restart|status|check}"
+	exit 1
+	;;
+esac
+
+exit 0

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -124,10 +124,10 @@ class solr::config(
     }
 
     exec { 'install-solr':
-      path    => [ '/bin', '/sbin' , '/usr/bin', '/usr/sbin', '/usr/local/bin' ],
-      command =>  "./install_solr_service.sh ${dist_root}/${dl_name} -d ${data_dir}",
-      cwd     =>  "$dist_root/bin",
-      onlyif  =>  "test ! -d ${data_dir}",
+      path    => [ '/bin', '/sbin' , '/usr/bin', '/usr/sbin', '/usr/local/bin', "${dist_root}/solr-${version}/bin" ],
+      command =>  "install_solr_service.sh ${dist_root}/${dl_name} -d ${data_dir}",
+      cwd     =>  "$dist_root/solr-${version}",
+      onlyif  =>  "test ! -d /opt/solr-${version}",
       require =>  Exec['extract-solr'],
     }
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,7 +24,7 @@ class solr::config(
   $dl_name        = "solr-${version}.tgz"
   $download_url   = "${mirror}/${version}/${dl_name}"
 
-  if versioncmp($::solr_version, '5.0') < 0 {
+  if versioncmp($::solr::version, '5.0') < 0 {
 
     #Copy the jetty config file
     file { '/etc/default/jetty':

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,80 +24,112 @@ class solr::config(
   $dl_name        = "solr-${version}.tgz"
   $download_url   = "${mirror}/${version}/${dl_name}"
 
-  #Copy the jetty config file
-  file { '/etc/default/jetty':
-    ensure  => file,
-    source  => 'puppet:///modules/solr/jetty-default',
-    require => Package['jetty'],
-  }
+  if versioncmp($::solr_version, '5.0') < 0 {
 
-  file { $solr_home:
-    ensure  => directory,
-    owner   => 'jetty',
-    group   => 'jetty',
-    require => Package['jetty'],
-  }
-
-  # download only if WEB-INF is not present and tgz file is not in $dist_root:
-  exec { 'solr-download':
-    path    => [ '/bin', '/sbin' , '/usr/bin', '/usr/sbin', '/usr/local/bin' ],
-    command =>  "wget ${download_url}",
-    cwd     =>  $dist_root,
-    creates =>  "${dist_root}/${dl_name}",
-    onlyif  =>  "test ! -d ${solr_home}/WEB-INF && test ! -f ${dist_root}/${dl_name}",
-    timeout =>  0,
-    require => File[$solr_home],
-  }
-
-  exec { 'extract-solr':
-    path    => [ '/bin', '/sbin' , '/usr/bin', '/usr/sbin', '/usr/local/bin' ],
-    command =>  "tar xvf ${dl_name}",
-    cwd     =>  $dist_root,
-    onlyif  =>  "test -f ${dist_root}/${dl_name} && test ! -d ${dist_root}/solr-${version}",
-    require =>  Exec['solr-download'],
-  }
-
-  # have to copy logging jars separately from solr 4.3 onwards
-  exec { 'copy-solr':
-    path    => [ '/bin', '/sbin' , '/usr/bin', '/usr/sbin', '/usr/local/bin' ],
-    command =>  "jar xvf ${dist_root}/solr-${version}/dist/solr-${version}.war; \
-    cp ${dist_root}/solr-${version}/example/lib/ext/*.jar WEB-INF/lib",
-    cwd     =>  $solr_home,
-    onlyif  =>  "test ! -d ${solr_home}/WEB-INF",
-    require =>  Exec['extract-solr'],
-  }
-
-  file { '/var/lib/solr':
-    ensure  => directory,
-    owner   => 'jetty',
-    group   => 'jetty',
-    mode    => '0700',
-    require => Package['jetty'],
-  }
-
-  file { "${solr_home}/solr.xml":
-    ensure  => 'file',
-    owner   => 'jetty',
-    group   => 'jetty',
-    content => template('solr/solr.xml.erb'),
-    require => File['/etc/default/jetty'],
-  }
-
-  file { "${jetty_home}/webapps/solr":
-    ensure  => 'link',
-    target  => $solr_home,
-    require => File["${solr_home}/solr.xml"],
-  }
-  if is_hash($cores) {
-    create_resources('::solr::core', $cores, {})
-  }
-  elsif is_array($cores) or is_string($cores) {
-    solr::core { $cores:
-      require   =>  File["${jetty_home}/webapps/solr"],
+    #Copy the jetty config file
+    file { '/etc/default/jetty':
+      ensure  => file,
+      source  => 'puppet:///modules/solr/jetty-default',
+      require => Package['jetty'],
     }
-  }
-  else {
-    fail('Parameter cores must be a hash, array or string')
+
+    file { $solr_home:
+      ensure  => directory,
+      owner   => 'jetty',
+      group   => 'jetty',
+      require => Package['jetty'],
+    }
+
+    # download only if WEB-INF is not present and tgz file is not in $dist_root:
+    exec { 'solr-download':
+      path    => [ '/bin', '/sbin' , '/usr/bin', '/usr/sbin', '/usr/local/bin' ],
+      command =>  "wget ${download_url}",
+      cwd     =>  $dist_root,
+      creates =>  "${dist_root}/${dl_name}",
+      onlyif  =>  "test ! -d ${solr_home}/WEB-INF && test ! -f ${dist_root}/${dl_name}",
+      timeout =>  0,
+      require => File[$solr_home],
+    }
+
+    exec { 'extract-solr':
+      path    => [ '/bin', '/sbin' , '/usr/bin', '/usr/sbin', '/usr/local/bin' ],
+      command =>  "tar xvf ${dl_name}",
+      cwd     =>  $dist_root,
+      onlyif  =>  "test -f ${dist_root}/${dl_name} && test ! -d ${dist_root}/solr-${version}",
+      require =>  Exec['solr-download'],
+    }
+
+    # have to copy logging jars separately from solr 4.3 onwards
+    exec { 'copy-solr':
+      path    => [ '/bin', '/sbin' , '/usr/bin', '/usr/sbin', '/usr/local/bin' ],
+      command =>  "jar xvf ${dist_root}/solr-${version}/dist/solr-${version}.war; \
+      cp ${dist_root}/solr-${version}/example/lib/ext/*.jar WEB-INF/lib",
+      cwd     =>  $solr_home,
+      onlyif  =>  "test ! -d ${solr_home}/WEB-INF",
+      require =>  Exec['extract-solr'],
+    }
+
+    file { '/var/lib/solr':
+      ensure  => directory,
+      owner   => 'jetty',
+      group   => 'jetty',
+      mode    => '0700',
+      require => Package['jetty'],
+    }
+
+    file { "${solr_home}/solr.xml":
+      ensure  => 'file',
+      owner   => 'jetty',
+      group   => 'jetty',
+      content => template('solr/solr.xml.erb'),
+      require => File['/etc/default/jetty'],
+    }
+
+    file { "${jetty_home}/webapps/solr":
+      ensure  => 'link',
+      target  => $solr_home,
+      require => File["${solr_home}/solr.xml"],
+    }
+
+    if is_hash($cores) {
+      create_resources('::solr::core', $cores, {})
+    }
+    elsif is_array($cores) or is_string($cores) {
+      solr::core { $cores:
+        require   =>  File["${jetty_home}/webapps/solr"],
+      }
+    }
+    else {
+      fail('Parameter cores must be a hash, array or string')
+    }
+  } else {
+    # SOLR 5.x or higher install  here
+
+    # download only if WEB-INF is not present and tgz file is not in $dist_root:
+    exec { 'solr-download':
+      path    => [ '/bin', '/sbin' , '/usr/bin', '/usr/sbin', '/usr/local/bin' ],
+      command =>  "wget ${download_url}",
+      cwd     =>  $dist_root,
+      creates =>  "${dist_root}/${dl_name}",
+      onlyif  =>  "test ! -d ${solr_home}/WEB-INF && test ! -f ${dist_root}/${dl_name}",
+      timeout =>  0,
+    }
+
+    exec { 'extract-solr':
+      path    => [ '/bin', '/sbin' , '/usr/bin', '/usr/sbin', '/usr/local/bin' ],
+      command =>  "tar xvf ${dl_name}",
+      cwd     =>  $dist_root,
+      onlyif  =>  "test -f ${dist_root}/${dl_name} && test ! -d ${dist_root}/solr-${version}",
+      require =>  Exec['solr-download'],
+    }
+
+    exec { 'install-solr':
+      path    => [ '/bin', '/sbin' , '/usr/bin', '/usr/sbin', '/usr/local/bin' ],
+      command =>  "./install_solr_service.sh ${dist_root}/${dl_name} -d ${data_dir}",
+      cwd     =>  "$dist_root/bin",
+      onlyif  =>  "test ! -d ${data_dir}",
+      require =>  Exec['extract-solr'],
+    }
   }
 }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,7 +32,7 @@ class solr::config(
   $download_url   = "${mirror}/${version}/${dl_name}"
 
   $jsp_jar = 'jsp-2.1-6.0.2.jar'
-  $jsp_url = "http://maven.ibiblio.org/maven2/jetty/jsp/2.1-6.0.2/${jsp_jar}"
+  $jsp_url = "http://uk.maven.org/maven2/jetty/jsp/2.1-6.0.2/${jsp_jar}"
 
   # This works for versions < 5.0 
   if versioncmp($::solr::version, '5.0') < 0 {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -31,7 +31,7 @@ class solr::install {
     }
 
   } else {
-    ensure_packages(['ython-software-properties', 'software-properties-common'])
+    ensure_packages(['python-software-properties', 'software-properties-common'])
     exec { 'install-java8-for-solr':
       command => "add-apt-repository -y ppa:webupd8team/java; apt-get -y update; echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections; apt-get -y install oracle-java8-installer",
       require => Package['python-software-properties', 'software-properties-common'],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -31,6 +31,7 @@ class solr::install {
     }
 
   } else {
+    ensure_packages(['ython-software-properties', 'software-properties-common'])
     exec { 'install-java8-for-solr':
       command => "add-apt-repository -y ppa:webupd8team/java; apt-get -y update; echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections; apt-get -y install oracle-java8-installer",
       require => Package['python-software-properties', 'software-properties-common'],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -31,11 +31,10 @@ class solr::install {
     }
 
   } else {
-    include java
-    java::oracle { 'jdk8' :
-        ensure  => 'present',
-        version => '8',
-        java_se => 'jdk',
+    exec { 'install-java8-for-solr':
+      command => "add-apt-repository -y ppa:webupd8team/java; apt-get -y update; echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections; apt-get -y install oracle-java8-installer",
+      require => Package['python-software-properties', 'software-properties-common'],
+      creates => "/usr/lib/jvm/java-8-oracle"
     }
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,18 +14,29 @@ class solr::install {
       }
   }
 
-  if ! defined(Package['jetty']) {
-      package { 'jetty':
-          ensure  => present,
-          require => Package['default-jdk'],
-      }
-  }
+  if versioncmp($::solr_version, '5.0') < 0 {
 
-  if ! defined(Package['libjetty-extra']) {
-      package { 'libjetty-extra':
-          ensure  => present,
-          require => Package['jetty'],
-      }
+    if ! defined(Package['jetty']) {
+        package { 'jetty':
+            ensure  => present,
+            require => Package['default-jdk'],
+        }
+    }
+
+    if ! defined(Package['libjetty-extra']) {
+        package { 'libjetty-extra':
+            ensure  => present,
+            require => Package['jetty'],
+        }
+    }
+
+  } else {
+    include java
+    java::oracle { 'jdk8' :
+        ensure  => 'present',
+        version => '8',
+        java_se => 'jdk',
+    }
   }
 
   if ! defined(Package['wget']) {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -61,6 +61,15 @@ class solr::install {
             require => Package['openjdk-7-jre-headless'],
           }
         }
+
+        file { '/etc/init.d/jetty8':
+          ensure  => present,
+          group   => root,
+          owner   => root,
+          mode    => '0755',
+          replace => yes,
+          source  => 'puppet:///modules/solr/jetty8',
+          require => Package['jetty8'],
       }
       default: { }
     }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,7 +14,7 @@ class solr::install {
       }
   }
 
-  if versioncmp($::solr_version, '5.0') < 0 {
+  if versioncmp($::solr::version, '5.0') < 0 {
 
     if ! defined(Package['jetty']) {
         package { 'jetty':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,4 +32,5 @@ class solr::params {
       $jetty_package = 'jetty8'
       $jdk_dirs = '/usr/lib/jvm/default-java /usr/lib/jvm/java-7-openjdk-amd64'
     }
+  }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,14 +6,15 @@
 #
 class solr::service {
 
-  #restart after copying new config
-  service { 'jetty':
-    ensure     => running,
-    hasrestart => true,
-    hasstatus  => true,
-    require    => Package['jetty'],
+  if versioncmp($::solr::version, '5.0') < 0 {
+    #restart after copying new config
+    service { 'jetty':
+      ensure     => running,
+      hasrestart => true,
+      hasstatus  => true,
+      require    => Package['jetty'],
+    }
   }
-
 }
 
 

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,6 @@
     }
   ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib" },
-    { "name": "puppetlabs/java","version_requirement":">= 1.6.0" }
+    { "name": "puppetlabs/stdlib" }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -16,6 +16,7 @@
     }
   ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib" }
+    { "name": "puppetlabs/stdlib" },
+    { "name": "puppetlabs/java","version_requirement":">= 1.6.0" }
   ]
 }

--- a/templates/jetty-default.erb
+++ b/templates/jetty-default.erb
@@ -25,7 +25,7 @@ JETTY_PORT=8983
 #JETTY_ARGS=
 
 # Extra options to pass to the JVM         
-JAVA_OPTIONS="-Dsolr.solr.home=/usr/share/solr -Dsolr.data.dir=/var/lib/solr $JAVA_OPTIONS"
+JAVA_OPTIONS="-Xss1280k -Dsolr.solr.home=/usr/share/solr -Dsolr.data.dir=/var/lib/solr $JAVA_OPTIONS"
 
 # Home of Java installation.
 # JAVA_HOME=


### PR DESCRIPTION
When systemd was starting jetty8 at boot time, it was encountering an error:
1. /etc/init.d/jetty8 start -- starts the service, waits 5 seconds, then checks if it started
2. Service took longer than 5 seconds to start, but it *DID* start
3. Systemd incorrectly flagged the service as not starting when in fact it had
4. Causes issues with Puppet when it checks in complaining the service wasn't starting (when it had)

Increasing the sleep time from 5 seconds to 10 seconds resolves this. Perhaps when the machine is starting jetty8, it is doing a bunch of other things at the same time and this slows down the start of the service such that 5 seconds is not enough.

This PR replaces the /etc/init.d/jetty8 init script with one that has a 10 second timeout.
A more long term solution would mean most likely writing a separate unit file for jetty8 and removing the /etc/init.d/jetty8 script, but this way is quicker and solves the issue without a lot of work and testing.